### PR TITLE
Change date format requirement from ISO to RFC3339

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ command line like this:
 Normalized, in this case, means:
 
 * The entire CSV is in the UTF-8 character set.
-* The `Timestamp` column should be formatted in ISO-8601 format.
+* The `Timestamp` column should be formatted in RFC3339 format.
 * The `Timestamp` column should be assumed to be in US/Pacific time;
   please convert it to US/Eastern.
 * All `ZIP` codes should be formatted as 5 digits. If there are less


### PR DESCRIPTION
We seem to have consensus that RFC3339 is clearer and simpler, which could make it more straightforward for reviewers to validate that the submitted code meets our spec.

Edit: For posterity, :lock:[thread](https://trussworks.slack.com/archives/CDJ9JAD26/p1581439413173400?thread_ts=1581352441.153800&cid=CDJ9JAD26) where this was discussed, so other people don't have to look it up like I just did :o)