### PR TITLE
Add draft of new browser-based exercise

### DIFF
--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -24,26 +24,26 @@ thought process if you do.
 
 We will review your solution in a recent version of Firefox, Chrome, or Safari.
 
-If you have any questions, please contact hiring@truss.works; we're
+If you have any questions, please contact [hiring@truss.works](mailto:hiring@truss.works); we're
 happy to help if you're not sure what we're asking for or if you have
 questions.
 
 ## How to submit your response
 
-Please submit your solution by emailing hiring@truss.works a link to **one** of the following:
+Please submit your solution by emailing [hiring@truss.works](mailto:hiring@truss.works) a link to **one** of the following:
 
-* A public git repository (Github is fine) that contains your code and a `README.md` that tells us how to build and run it.
-* Your solution running in an online IDE such as [CodePen](https://codepen.io) or [Glitch](https://glitch.com).
+-   A public git repository (Github is fine) that contains your code and a `README.md` that tells us how to build and run it.
+-   Your solution running in an online IDE such as [CodePen](https://codepen.io) or [Glitch](https://glitch.com).
 
 Please ensure that your submission includes everything needed to run and view your project:
 
-* If your solution code requires compilation (such as with a tool like webpack or create-react-app),
-  please provide as a part of your submission complete instructions for running your code, including
-  a `package.json` file with all dependencies included.
-* If your solution is in the form of static assets (such as an index.html file), we will run it
-  using a simple no-config HTTP server (<https://github.com/vercel/serve>).
-* If your solution is on a hosted IDE such as Codepen or Glitch, please make sure to
-  provide an evergreen link that does not expire.
+-   If your solution code requires compilation (such as with a tool like webpack or create-react-app),
+    please provide as a part of your submission complete instructions for running your code, including
+    a `package.json` file with all dependencies included.
+-   If your solution is in the form of static assets (such as an index.html file), we will run it
+    using a simple no-config HTTP server (<https://github.com/vercel/serve>).
+-   If your solution is on a hosted IDE such as Codepen or Glitch, please make sure to
+    provide an evergreen link that does not expire.
 
 ## The problem: Display data from an API for human consumption
 
@@ -62,26 +62,26 @@ generate and any code you write to load or display the data.
 
 For each planet in the dataset, please display:
 
-- The planet's name
-  - The name should be a link that, when clicked, opens the planet's API URL in a new window
-- The planet's climate
-- How many residents the planet has
-- The terrains found on the planet
-- The population
-- The surface area covered by water
-  - Assume that all planets are perfect spheres.
-  - The radius of a sphere is half its diameter.
-  - The value of `surface_water` from the API is a percentage, so a value of `50` means the planet is 50% covered in water.
+-   The planet's name
+    -   The name should be a link that, when clicked, opens the planet's API URL in a new window
+-   The planet's climate
+-   How many residents the planet has
+-   The terrains found on the planet
+-   The population
+-   The surface area covered by water
+    -   Assume that all planets are perfect spheres.
+    -   The radius of a sphere is half its diameter.
+    -   The value of `surface_water` from the API is a percentage, so a value of `50` means the planet is 50% covered in water.
 
 Additionally, please satisfy these requirements:
 
-- Show a loading message while loading the data, and hide this message once the data is displayed.
-- Display an error message if the data load fails for some reason. We may test your code against an invalid URL to demonstrate this.
-- Sort the planets alphabetically
-- Any column that is unknown should be displayed as `?`.
-- Format all numbers larger than 999 with spaces to group digits into groups of three.
-  For example, ten thousand should be displayed as `10 000`.
-- Cells in the table should be separated by 1 pixel gray lines.
+-   Show a loading message while loading the data, and hide this message once the data is displayed.
+-   Display an error message if the data load fails for some reason. We may test your code against an invalid URL to demonstrate this.
+-   Sort the planets alphabetically
+-   Any column that is unknown should be displayed as `?`.
+-   Format all numbers larger than 999 with spaces to group digits into groups of three.
+    For example, ten thousand should be displayed as `10 000`.
+-   Cells in the table should be separated by 1 pixel gray lines.
 
 ### Stretch goals (optional)
 
@@ -89,9 +89,9 @@ If you complete the above and still have additional time, you can choose to comp
 
 **This is absolutely not required for submitting the work sample and should not be worked on beyond the four hour time limit.**
 
-- The API only returns the first page of data by default. Add a "load more" button that
-  loads additional pages of data when clicked. Only show this button if there is more data to be loaded.
-- Sort the table by a column's values when that column's header is clicked.
-- Spruce up your page with some extra styling & design elements!
-- Make sure your page is usable on mobile devices.
-- Include some tests.
+-   The API only returns the first page of data by default. Add a "load more" button that
+    loads additional pages of data when clicked. Only show this button if there is more data to be loaded.
+-   Sort the table by a column's values when that column's header is clicked.
+-   Spruce up your page with some extra styling & design elements!
+-   Make sure your page is usable on mobile devices.
+-   Include some tests.

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -15,7 +15,6 @@ on it.
 If you have any questions, please contact [hiring@truss.works](mailto:hiring@truss.works); we're
 happy to help.
 
-
 ## How to submit your response
 
 Please submit your solution by emailing [hiring@truss.works](mailto:hiring@truss.works) a link to **one** of the following:
@@ -33,7 +32,7 @@ Please ensure that your submission includes everything needed to run and view yo
 -   If your solution is on a hosted IDE such as Codepen or Glitch, please make sure to
     provide an evergreen link that does not expire.
     
-We will review your solution in a recent version of Firefox, Chrome, or Safari.
+We will review your solution in a recent version of Firefox, Chrome, or Safari running on MacOS.
 
 ## Full Description 
 

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -72,6 +72,7 @@ For each planet in the dataset, please display:
     -   Assume that all planets are perfect spheres.
     -   The radius of a sphere is half its diameter.
     -   The value of `surface_water` from the API is a percentage, so a value of `50` means the planet is 50% covered in water.
+    -   Round these values to the nearest integer value.
 
 Additionally, please satisfy these requirements:
 

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -56,19 +56,21 @@ generate and any code you write to load or display the data.
 For each planet in the dataset, please display:
 
 - The planet's name
+    - The name should be a link that, when clicked, opens the planet's API URL in a new window
 - The planet's climate
 - How many residents the planet has
-- The terrains found on the planet. Please use an unordered list (`ul`) to structure these and wrap each terrain in a list item (`li`).
+- The terrains found on the planet
 - The population
 - The surface area covered by water
     - Assume that all planets are perfect spheres.
     - The radius of a sphere is half its diameter.
-    - The `surface_water` value in the data is a percent, so `50` means the planet is 50% covered in water.
+    - The value of `surface_water` from the API is a percentage, so a value of `50` means the planet is 50% covered in water.
 
 Additionally, please satisfy these requirements:
 
 - Show a loading message while loading the data, and hide this message once the data is displayed.
-- Sort the planets by name, showing earlier letters first.
+- Display an error message if the data load fails for some reason. We may test your code against an invalid URL to demonstrate this.
+- Sort the planets alphabetically
 - Any column that is unknown should be displayed as `?`.
 - Format all numbers larger than 999 with spaces to group digits into groups of three.
   For example, ten thousand should be displayed as `10 000`.
@@ -78,8 +80,11 @@ Additionally, please satisfy these requirements:
 
 If you complete the above and still have additional time, you can choose to complete one or more of the following extra requirements.
 
-**This is absolutely not required for submitting the work sample.**
+**This is absolutely not required for submitting the work sample and should not be worked on beyond the four hour time limit.**
 
 - The API only returns the first page of data by default. Add a "load more" button that
   loads additional pages of data when clicked. Only show this button if there is more data to be loaded.
 - Sort the table by a column's values when that column's header is clicked.
+- Spruce up your page with some extra styling & design elements!
+- Make sure your page is usable on mobile devices.
+- Include some tests.

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -1,0 +1,82 @@
+_This is one of the steps in the Truss interview process. If you've
+stumbled upon this repository and are interested in a career with
+Truss, [check out our jobs page](https://truss.works/jobs)._
+
+# Truss Software Engineering Interview
+
+## Introduction and expectations
+
+Hi there! Please complete the problem described below to the best of
+your ability, using the tools you're most comfortable with. Assume
+you're sending your submission in for code review from peers;
+we'll be talking about your submission in your interview in that
+context.
+
+We expect this to take less than 4 hours of actual coding time. Please
+submit a working but incomplete solution instead of spending more time
+on it. We're also aware that getting after-hours coding time can be
+challenging; we'd like a submission within a week and if you need more
+time please let us know.
+
+Approach this solution the way you would a real world problem. Use
+libraries where it makes sense to, and be prepared to explain your
+thought process if you do.
+
+If you have any questions, please contact hiring@truss.works; we're
+happy to help if you're not sure what we're asking for or if you have
+questions.
+
+## How to submit your response
+
+Please send hiring@truss.works a link to a public git repository
+(Github is fine) that contains your code and a README.md that tells us
+how to build and run it. Your code will be run in Firefox, Chrome, or Safari.
+
+## The problem: Display data from an API for human consumption
+
+Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that data
+in an HTML `table`.
+
+Name the entrypoint for your application `index.html`. To test your solution, we will open `index.html` in a browser.
+
+You may use additional files to organize your code, but please include submit
+a built version of the project that doesn't require the use of any build tools
+if you do. Accordingly, you may use any build tool you'd like as long as you
+include files that are ready for viewing directly in a browser.
+
+Don't worry about making the table look fancy; you can style it however you
+would like to outside the requirements below. We will look at the markup you
+generate and any code you write to load or display the data.
+
+## What to display
+
+For each planet in the dataset, please display:
+
+- The planet's name
+- The planet's climate
+- How many residents the planet has
+- The terrains found on the planet. Please use an unordered list (`ul`) to structure these and wrap each terrain in a list item (`li`).
+- The population
+- The surface area covered by water
+    - Assume that all planets are perfect spheres.
+    - The radius of a sphere is half its diameter.
+    - The `surface_water` value in the data is a percent, so `50` means the planet is 50% covered in water.
+
+Additionally, please satisfy these requirements:
+
+- Show a loading message while loading the data, and hide this message once the data is displayed.
+- Sort the planets by name, showing earlier letters first.
+- Any column that is unknown should be displayed as `?`.
+- Format all numbers larger than 999 with spaces to group digits into groups of three.
+  For example, ten thousand should be displayed as `10 000`.
+- Cells in the table should be separated by 1 pixel gray lines.
+
+## Stretch goals (optional)
+
+If you complete the above and still have additional time, you can choose to complete one or more of the following extra requirements.
+
+**This is absolutely not required for submitting the work sample.**
+
+- The API only returns the first page of data by default. Add a "load more" button that
+  loads additional pages of data when clicked. Only show this button if there is more data to be loaded.
+- Sort the table by a column's values when that column's header is clicked.

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -52,7 +52,7 @@ in an HTML `table`.
 
 Name the entrypoint for your application `index.html`.
 
-You may use additional files to organize your code. You may also use frameworks and build tools as long as clear, simple instructions are provided for how to run. Please ensure your solution can be easily viewed in the browser. Be ready to answer questions about why you chose a given approach.
+You may use additional files to organize your code. You may also use frameworks and build tools as long as clear, simple instructions are provided for how to run them. Please ensure your solution can be easily viewed in the browser. Be ready to answer questions about why you chose a given approach.
 
 Don't worry about making the table look fancy; you can style it however you
 would like to outside the requirements below. We will look at the markup you

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -92,6 +92,7 @@ If you complete the above and still have additional time, you can choose to comp
 -   The API only returns the first page of data by default. Add a "load more" button that
     loads additional pages of data when clicked. Only show this button if there is more data to be loaded.
 -   Sort the table by a column's values when that column's header is clicked.
+-   Table has both an empty state and loading state (when no data exists and when data is still loading accordingly).
 -   Spruce up your page with some extra styling & design elements!
 -   Make sure your page is usable on mobile devices.
 -   Include some tests.

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -40,12 +40,10 @@ Please submit your solution by emailing hiring@truss.works a link to **one** of 
 Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that data
 in an HTML `table`.
 
-Name the entrypoint for your application `index.html`. To test your solution, we will open `index.html` in a browser.
+Name the entrypoint for your application `index.html`. 
 
-You may use additional files to organize your code, but please include 
-a built version of the project that doesn't require any build tools in your
-submission if you do. Accordingly, you may use any build tool you'd like
-as long as you include files that are ready for viewing directly in a browser.
+You may use additional files to organize your code. You may also use frameworks and build tools as long as clear, simple instructions are provided for how to run. Please ensure your solution can be easily viewed in the browser. Be ready to answer questions about why you chose a given approach.
+
 
 Don't worry about making the table look fancy; you can style it however you
 would like to outside the requirements below. We will look at the markup you

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -26,7 +26,7 @@ Please submit your solution by emailing [hiring@truss.works](mailto:hiring@truss
 Please ensure that your submission includes everything needed to run and view your project:
 
 -   If your solution code requires compilation (such as with a tool like webpack or create-react-app),
-    please provide as a part of your submission complete instructions for running your code, including
+    please provide complete instructions for running your code, including
     a `package.json` file with all dependencies included.
 -   If your solution is in the form of static assets (such as an index.html file), we will run it
     using a simple no-config HTTP server (<https://github.com/vercel/serve>).
@@ -37,14 +37,14 @@ We will review your solution in a recent version of Firefox, Chrome, or Safari.
 
 ## Full Description 
 
-Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that datain an HTML `table`.
+Please write a static webpage that loads data from `https://swapi.dev/api/planets/`, formats and displays that data in a table.
 
 Name the entrypoint for your application `index.html`.
 
 You may use additional files to organize your code. You may also use frameworks and build tools as long as clear, simple instructions are provided for how to run them. Please ensure your solution can be easily viewed in the browser. Be ready to answer questions about why you chose a given approach.
 
 Don't worry about making the table look fancy; you can style it however you
-would like to outside the requirements below. We will look at the markup you
+would like to alongside the requirements below. We will look at the markup you
 generate and any code you write to load or display the data.
 
 For each planet in the dataset, please display:
@@ -80,7 +80,7 @@ If you complete the above and still have additional time, you can choose to comp
 -   The API only returns the first page of data by default. Add a "load more" button that
     loads additional pages of data when clicked. Only show this button if there is more data to be loaded.
 -   Sort the table by a column's values when that column's header is clicked.
--   Table has both an empty state and loading state (when no data exists and when data is still loading accordingly).
+-   Table has both an empty state and loading state (displayed when no data exists, and when data is loading respectively).
 -   Spruce up your page with some extra styling & design elements!
 -   Make sure your page is usable on mobile devices.
 -   Include some tests.

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -22,15 +22,18 @@ Approach this solution the way you would a real world problem. Use
 libraries where it makes sense to, and be prepared to explain your
 thought process if you do.
 
+We will review your solution in a recent version of Firefox, Chrome, or Safari.
+
 If you have any questions, please contact hiring@truss.works; we're
 happy to help if you're not sure what we're asking for or if you have
 questions.
 
 ## How to submit your response
 
-Please send hiring@truss.works a link to a public git repository
-(Github is fine) that contains your code and a README.md that tells us
-how to build and run it. Your code will be run in Firefox, Chrome, or Safari.
+Please submit your solution by emailing hiring@truss.works a link to **one** of the following:
+
+- A public git repository (Github is fine) that contains your code and a `README.md` that tells us how to build and run it.
+- Your solution running in an online IDE such as [CodePen](https://codepen.io) or [Glitch](https://glitch.com).
 
 ## The problem: Display data from an API for human consumption
 

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -32,7 +32,8 @@ Please ensure that your submission includes everything needed to run and view yo
     using a simple no-config HTTP server (<https://github.com/vercel/serve>).
 -   If your solution is on a hosted IDE such as Codepen or Glitch, please make sure to
     provide an evergreen link that does not expire.
-
+    
+We will review your solution in a recent version of Firefox, Chrome, or Safari.
 
 ## Full Description 
 

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -2,31 +2,19 @@ _This is one of the steps in the Truss interview process. If you've
 stumbled upon this repository and are interested in a career with
 Truss, [check out our jobs page](https://truss.works/jobs)._
 
-# Truss Software Engineering Interview
+# The problem: Display data from an API for human consumption
 
-## Introduction and expectations
-
-Hi there! Please complete the problem described below to the best of
-your ability, using the tools you're most comfortable with. Assume
-you're sending your submission in for code review from peers;
-we'll be talking about your submission in your interview in that
-context.
-
-We expect this to take less than 4 hours of actual coding time. Please
-submit a working but incomplete solution instead of spending more time
-on it. We're also aware that getting after-hours coding time can be
-challenging; we'd like a submission within a week and if you need more
-time please let us know.
+## Introduction
 
 Approach this solution the way you would a real world problem. Use
 libraries where it makes sense to, and be prepared to explain your
-thought process if you do.
-
-We will review your solution in a recent version of Firefox, Chrome, or Safari.
+thought process if you do. We expect this to take less than 4 hours of actual coding time. Please
+submit a working but incomplete solution instead of spending more time
+on it.
 
 If you have any questions, please contact [hiring@truss.works](mailto:hiring@truss.works); we're
-happy to help if you're not sure what we're asking for or if you have
-questions.
+happy to help.
+
 
 ## How to submit your response
 
@@ -45,10 +33,10 @@ Please ensure that your submission includes everything needed to run and view yo
 -   If your solution is on a hosted IDE such as Codepen or Glitch, please make sure to
     provide an evergreen link that does not expire.
 
-## The problem: Display data from an API for human consumption
 
-Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that data
-in an HTML `table`.
+## Full Description 
+
+Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that datain an HTML `table`.
 
 Name the entrypoint for your application `index.html`.
 
@@ -57,8 +45,6 @@ You may use additional files to organize your code. You may also use frameworks 
 Don't worry about making the table look fancy; you can style it however you
 would like to outside the requirements below. We will look at the markup you
 generate and any code you write to load or display the data.
-
-### What to display
 
 For each planet in the dataset, please display:
 
@@ -86,7 +72,7 @@ Additionally, please satisfy these requirements:
 
 ### Stretch goals (optional)
 
-If you complete the above and still have additional time, you can choose to complete one or more of the following extra requirements.
+If you complete the above and still have additional time, you can choose to complete one or more of the following.
 
 **This is absolutely not required for submitting the work sample and should not be worked on beyond the four hour time limit.**
 

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -32,26 +32,29 @@ questions.
 
 Please submit your solution by emailing hiring@truss.works a link to **one** of the following:
 
-- A public git repository (Github is fine) that contains your code and a `README.md` that tells us how to build and run it.
-- Your solution running in an online IDE such as [CodePen](https://codepen.io) or [Glitch](https://glitch.com).
+* A public git repository (Github is fine) that contains your code and a `README.md` that tells us how to build and run it.
+* Your solution running in an online IDE such as [CodePen](https://codepen.io) or [Glitch](https://glitch.com).
+
+Please ensure that your submission includes everything needed to run and view your project:
+
+* If your solution code requires compilation (such as with a tool like webpack or create-react-app),
+  please provide as a part of your submission complete instructions for running your code, including
+  a `package.json` file with all dependencies included.
+* If your solution is in the form of static assets (such as an index.html file), we will run it
+  using a simple no-config HTTP server (https://github.com/vercel/serve).
+* If your solution is on a hosted IDE such as Codepen or Glitch, please make sure to
+  provide an evergreen link that does not expire.
 
 ## The problem: Display data from an API for human consumption
 
 Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that data
 in an HTML `table`.
 
-Name the entrypoint for your application `index.html`. To test your solution, we will open `index.html` in a browser.
-
-You may use additional files to organize your code, but please include 
-a built version of the project that doesn't require any build tools in your
-submission if you do. Accordingly, you may use any build tool you'd like
-as long as you include files that are ready for viewing directly in a browser.
-
 Don't worry about making the table look fancy; you can style it however you
 would like to outside the requirements below. We will look at the markup you
 generate and any code you write to load or display the data.
 
-## What to display
+### What to display
 
 For each planet in the dataset, please display:
 
@@ -76,7 +79,7 @@ Additionally, please satisfy these requirements:
   For example, ten thousand should be displayed as `10 000`.
 - Cells in the table should be separated by 1 pixel gray lines.
 
-## Stretch goals (optional)
+### Stretch goals (optional)
 
 If you complete the above and still have additional time, you can choose to complete one or more of the following extra requirements.
 

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -39,10 +39,10 @@ in an HTML `table`.
 
 Name the entrypoint for your application `index.html`. To test your solution, we will open `index.html` in a browser.
 
-You may use additional files to organize your code, but please include submit
-a built version of the project that doesn't require the use of any build tools
-if you do. Accordingly, you may use any build tool you'd like as long as you
-include files that are ready for viewing directly in a browser.
+You may use additional files to organize your code, but please include 
+a built version of the project that doesn't require any build tools in your
+submission if you do. Accordingly, you may use any build tool you'd like
+as long as you include files that are ready for viewing directly in a browser.
 
 Don't worry about making the table look fancy; you can style it however you
 would like to outside the requirements below. We will look at the markup you

--- a/CSV_README.md
+++ b/CSV_README.md
@@ -1,0 +1,70 @@
+_This is one of the steps in the Truss interview process. If you've
+stumbled upon this repository and are interested in a career with
+Truss, [check out our jobs page](https://truss.works/jobs)._
+
+# The problem: CSV normalization
+
+## Introduction
+
+Approach this solution the way you would a real world problem. Use
+libraries where it makes sense to, and be prepared to explain your
+thought process if you do. We expect this to take less than 4 hours of actual coding time. Please
+submit a working but incomplete solution instead of spending more time
+on it.
+
+If you have any questions, please contact [hiring@truss.works](mailto:hiring@truss.works); we're
+happy to help.
+
+## How to submit your response
+
+Please submit your solution by emailing [hiring@truss.works](mailto:hiring@truss.works) with a link to a public git repository
+(Github is fine) that contains your code and a README.md that tells us
+how to build and run it. Your code will be run on either macOS 10.15
+or Ubuntu 16.04 LTS, your choice.
+
+## Full Description
+
+Please write a tool that reads a CSV formatted file on `stdin` and
+emits a normalized CSV formatted file on `stdout`. For example, if
+your program was named `normalizer` we would test your code on the
+command line like this:
+
+```sh
+./normalizer < sample.csv > output.csv
+```
+
+Normalized, in this case, means:
+
+* The entire CSV is in the UTF-8 character set.
+* The `Timestamp` column should be formatted in RFC3339 format.
+* The `Timestamp` column should be assumed to be in US/Pacific time;
+  please convert it to US/Eastern.
+* All `ZIP` codes should be formatted as 5 digits. If there are less
+  than 5 digits, assume 0 as the prefix.
+* The `FullName` column should be converted to uppercase. There will be
+  non-English names.
+* The `Address` column should be passed through as is, except for
+  Unicode validation. Please note there are commas in the Address
+  field; your CSV parsing will need to take that into account. Commas
+  will only be present inside a quoted string.
+* The `FooDuration` and `BarDuration` columns are in HH:MM:SS.MS
+  format (where MS is milliseconds); please convert them to the
+  total number of seconds expressed in floating point format.
+  You should not round the result.
+* The `TotalDuration` column is filled with garbage data. For each
+  row, please replace the value of `TotalDuration` with the sum of
+  `FooDuration` and `BarDuration`.
+* The `Notes` column is free form text input by end-users; please do
+  not perform any transformations on this column. If there are invalid
+  UTF-8 characters, please replace them with the Unicode Replacement
+  Character.
+
+You can assume that the input document is in UTF-8 and that any times
+that are missing timezone information are in US/Pacific. If a
+character is invalid, please replace it with the Unicode Replacement
+Character. If that replacement makes data invalid (for example,
+because it turns a date field into something unparseable), print a
+warning to `stderr` and drop the row from your output.
+
+You can assume that the sample data we provide will contain all date
+and time format variants you will need to handle.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Truss, [check out our jobs page](https://truss.works/jobs)._
 
 ## Introduction and expectations
 
-Hi there! Please *choose one** of the problems described below. Solve to the best of
+Hi there! Please choose *one* of the problems described below. Solve to the best of
 your ability, using the tools you're most comfortable with. Assume
 you're sending your submission in for code review from peers;
 we'll be talking about your submission in your interview in that
@@ -20,11 +20,11 @@ time please let us know.
 
 ### How to submit your response
 
-Please submit your solution by emailing a link to [hiring@truss.works](mailto:hiring@truss.works).  More details on what we are looking for are in the linked files below.
+Please submit your solution by emailing a link to [hiring@truss.works](mailto:hiring@truss.works).  More details on what we are looking for are in the problem READMEs linked below.
 
 ## Choose one problem to work on
 
-A README for each is linked below.
+A README with specific instructions for each problem is linked below.
 
 ### The problem: [CSV normalization](CSV_README.md)
 
@@ -39,6 +39,6 @@ command line like this:
 
 ### The problem: [Display data from an API for human consumption](BROWSER_README.md)
 
-Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that data in an HTML `table`. Name the entrypoint for your application `index.html`.
+Please write a static webpage that loads data from a specified public API, and formats & displays that data in HTML. You may use libraries, frameworks and/or build tools as long as clear, simple instructions are provided for how to run them. Please ensure your solution can be easily viewed in the browser.
 
 You may use additional files to organize your code. You may also use frameworks and build tools as long as clear, simple instructions are provided for how to run them. Please ensure your solution can be easily viewed in the browser.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Truss, [check out our jobs page](https://truss.works/jobs)._
 
 ## Introduction and expectations
 
-Hi there! Please complete the problem described below to the best of
+Hi there! Please *choose one** of the problems described below. Solve to the best of
 your ability, using the tools you're most comfortable with. Assume
 you're sending your submission in for code review from peers;
 we'll be talking about your submission in your interview in that
@@ -18,22 +18,15 @@ on it. We're also aware that getting after-hours coding time can be
 challenging; we'd like a submission within a week and if you need more
 time please let us know.
 
-Approach this solution the way you would a real world problem. Use
-libraries where it makes sense to, and be prepared to explain your
-thought process if you do.
+### How to submit your response
 
-If you have any questions, please contact hiring@truss.works; we're
-happy to help if you're not sure what we're asking for or if you have
-questions.
+Please submit your solution by emailing a link to [hiring@truss.works](mailto:hiring@truss.works).  More details on what we are looking for are in the linked files below.
 
-## How to submit your response
+## Choose one problem to work on
 
-Please send hiring@truss.works a link to a public git repository
-(Github is fine) that contains your code and a README.md that tells us
-how to build and run it. Your code will be run on either macOS 10.15
-or Ubuntu 16.04 LTS, your choice.
+A README for each is linked below.
 
-## The problem: CSV normalization
+### The problem: [CSV normalization](CSV_README.md)
 
 Please write a tool that reads a CSV formatted file on `stdin` and
 emits a normalized CSV formatted file on `stdout`. For example, if
@@ -44,38 +37,8 @@ command line like this:
 ./normalizer < sample.csv > output.csv
 ```
 
-Normalized, in this case, means:
+### The problem: [Display data from an API for human consumption](BROWSER_README.md)
 
-* The entire CSV is in the UTF-8 character set.
-* The `Timestamp` column should be formatted in RFC3339 format.
-* The `Timestamp` column should be assumed to be in US/Pacific time;
-  please convert it to US/Eastern.
-* All `ZIP` codes should be formatted as 5 digits. If there are less
-  than 5 digits, assume 0 as the prefix.
-* The `FullName` column should be converted to uppercase. There will be
-  non-English names.
-* The `Address` column should be passed through as is, except for
-  Unicode validation. Please note there are commas in the Address
-  field; your CSV parsing will need to take that into account. Commas
-  will only be present inside a quoted string.
-* The `FooDuration` and `BarDuration` columns are in HH:MM:SS.MS
-  format (where MS is milliseconds); please convert them to the
-  total number of seconds expressed in floating point format.
-  You should not round the result.
-* The `TotalDuration` column is filled with garbage data. For each
-  row, please replace the value of `TotalDuration` with the sum of
-  `FooDuration` and `BarDuration`.
-* The `Notes` column is free form text input by end-users; please do
-  not perform any transformations on this column. If there are invalid
-  UTF-8 characters, please replace them with the Unicode Replacement
-  Character.
+Please write a static webpage that loads data from `https://swapi.dev/api/planets/` and displays that data in an HTML `table`. Name the entrypoint for your application `index.html`.
 
-You can assume that the input document is in UTF-8 and that any times
-that are missing timezone information are in US/Pacific. If a
-character is invalid, please replace it with the Unicode Replacement
-Character. If that replacement makes data invalid (for example,
-because it turns a date field into something unparseable), print a
-warning to `stderr` and drop the row from your output.
-
-You can assume that the sample data we provide will contain all date
-and time format variants you will need to handle.
+You may use additional files to organize your code. You may also use frameworks and build tools as long as clear, simple instructions are provided for how to run them. Please ensure your solution can be easily viewed in the browser.


### PR DESCRIPTION
Here is a draft of a new hiring exercise. This is the result of meetings within the engineering hiring working group and additional discussions I had with @suzubara related to #10.

A breakdown of the topics covered in this exercise and how they map to those in the existing CSV/command-line exercise [can be viewed here](https://docs.google.com/spreadsheets/d/1FPK4wUg_nPpKKnj4fBS9e7DOlYrHOhYPRcAB56PSQCM/edit#gid=0).

Please take a look and raise any red flags. Once we have worked through any of those, a few of us can work through this exercise and see what changes we need to make to adjust the number and difficulty of requirements.

I didn't include the timezone and other time objectives as we had originally planned, as the underlying dataset doesn't include values useful for this purpose. I'm absolutely not attached to using any particular dataset here, and there are a couple ways to proceed if we so choose:

1. Use a different dataset
2. Provide our own dataset/API to hit so we can have more control. This was our plan but I haven't gotten to do this yet.