### PR TITLE
Remove "static" keyword from instructions

### DIFF
--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -36,7 +36,7 @@ We will review your solution in a recent version of Firefox, Chrome, or Safari r
 
 ## Full Description 
 
-Please write a static webpage that loads data from `https://swapi.dev/api/planets/`, formats and displays that data in a table.
+Please write a webpage that loads data from `https://swapi.dev/api/planets/`, formats and displays that data in a table.
 
 Name the entrypoint for your application `index.html`.
 


### PR DESCRIPTION
- Avoid confusion for candidates who might feel pushed away from using specific libraries/frameworks they are comfortable with.
- Introduction and Full Description sections provide clear guidance on library/framework usage as is.